### PR TITLE
feat: add --cli output and filtering options

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	models "github.com/hedibertosilva/pgdump-mapper/models"
 )
 
-var Options *models.Options
+var Options = &models.Options{}
+var Filters = &models.FilterOptions{}
 
 func HandleOptions(args []string) {
 	hasOptions := false
@@ -18,12 +20,29 @@ func HandleOptions(args []string) {
 		"--yaml":   &Options.Yaml,
 		"--html":   &Options.Html,
 		"--sqlite": &Options.Sqlite,
+		"--cli":    &Options.Cli,
 	}
 
 	for _, arg := range args {
 		if opt, exist := mapOptions[arg]; exist {
 			*opt = true
 			hasOptions = true
+			continue
+		}
+
+		if strings.HasPrefix(arg, "--") && strings.Contains(arg, "=") {
+			parts := strings.SplitN(arg, "=", 2)
+			key := parts[0]
+			value := parts[1]
+
+			switch key {
+			case "--table":
+				Filters.TableName = value
+				hasOptions = true
+			case "--columns":
+				Filters.Columns = strings.Split(value, ",")
+				hasOptions = true
+			}
 		}
 	}
 

--- a/internal/cli/messages.go
+++ b/internal/cli/messages.go
@@ -15,4 +15,7 @@ Options:
 	--json		Export as JSON.
 	--yaml		Export as YAML.
 	--html		Export as HTML. (default)
-	--sqlite    Export as SQLite.`
+	--sqlite    Export as SQLite.
+	--cli       Export as CLI table.
+	--table     Filter by table (valid only with --cli).
+	--columns   Filter by Columns (valid only with --cli).`

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	cli "github.com/hedibertosilva/pgdump-mapper/internal/cli"
 	errors "github.com/hedibertosilva/pgdump-mapper/internal/cli/errors"
@@ -15,7 +16,18 @@ func argsSanityCheck(args []string) error {
 	numOptions := 0
 	for _, arg := range args {
 		if _, exist := models.CatalogOptions[arg]; exist {
-			numOptions += 1
+			numOptions++
+			continue
+		}
+
+		// If the argument follow --key=value format, check if the key is in CatalogOptions
+		if strings.HasPrefix(arg, "--") && strings.Contains(arg, "=") {
+			parts := strings.SplitN(arg, "=", 2)
+			key := parts[0]
+			if _, exist := models.CatalogOptions[key]; exist {
+				numOptions++
+				continue
+			}
 		}
 	}
 

--- a/models/models.go
+++ b/models/models.go
@@ -6,6 +6,12 @@ type Options struct {
 	Yaml   bool
 	Html   bool
 	Sqlite bool
+	Cli bool
+}
+
+type FilterOptions struct {
+	TableName string
+	Columns   []string
 }
 
 var CatalogOptions = map[string]bool{
@@ -15,4 +21,7 @@ var CatalogOptions = map[string]bool{
 	"--yaml":   false,
 	"--html":   false,
 	"--sqlite": false,
+	"--cli": false,
+	"--table": false,
+	"--columns": false,
 }


### PR DESCRIPTION
This feature introduces the `--cli` flag to enable tabular output directly in the terminal.
Additionally, it adds filtering capabilities when using `--cli`:
 - `--table=<table_name>` filters the output to a specific table.
 - `--columns=col1,col2,...` restricts the output to specific columns.

Also, improvements were made to the HTML export:
 - Columns with more than one unique value now display a filter dropdown.

Test Plan:
 - Run the binary with `--cli` alone and verify full tabular output.
 - Run the binary with `--cli --table=...` and `--columns=...` to verify filtering behavior.
 - Run the binary with `--html` and confirm filter buttons appear only for columns with multiple values.